### PR TITLE
Install resources & fix AcidConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(Acid VERSION 0.10.8 LANGUAGES C CXX)
 option(BUILD_SHARED_LIBS "Build Shared Libraries" ON)
 option(BUILD_TESTS "Build test applications" ON)
 option(ACID_INSTALL_EXAMPLES "Installs the examples." ON)
+option(ACID_INSTALL_RESOURCES "Installs the Resources directory." ON)
 
 # To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
@@ -136,6 +137,15 @@ endif()
 
 # Acid sources directory
 add_subdirectory(Sources)
+
+if(ACID_INSTALL_RESOURCES)
+	# Install resources for end-user usage
+	# because many source files use these
+	install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Resources"
+			# Example: this will install the Resources dir to /usr/share/Acid/Resources on Linux
+			DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
+		)
+endif()
 
 # Allows automation of "BUILD_TESTING"
 include(CTest)

--- a/Sources/AcidConfig.cmake
+++ b/Sources/AcidConfig.cmake
@@ -1,9 +1,31 @@
+# This creates the IMPORTED TARGET Acid::Acid
+#
+# To use this...
+# target_link_libraries(yourliborexe Acid::Acid)
+#
+# Optionally use PRIVATE/PUBLIC based on your needs like so...
+# target_link_libraries(yourliborexe PRIVATE Acid::Acid)
+#
+# Because it's an IMPORTED TARGET, you don't need to include its headers seperately, it's handled for you
+
 include(CMakeFindDependencyMacro)
 # Since these are required for PUBLIC usage, they must be found here
 # Then people don't have to pre-emptively find_package(Threads) or Vulkan
 # before find_package(Acid)
-find_dependency(Threads REQUIRED)
-find_dependency(Vulkan REQUIRED)
+find_dependency(Threads)
+find_dependency(Vulkan)
 # Includes the targets which are in the same dir as this file
 # So CMAKE_CURRENT_LIST_DIR will be determined when calling find_package(Acid)
 include(${CMAKE_CURRENT_LIST_DIR}/AcidTargets.cmake)
+
+if(TARGET Acid::Acid)
+	# Note "Found Acid: " will be automatically prefixed by find_package_handle_standard_args
+	# Example output when doing find_package(Acid)...
+	# -- Found Acid: /usr/lib/libAcid.so  
+	get_property(_ACID_TARGET_LOCATION TARGET Acid::Acid PROPERTY LOCATION)
+endif()
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Acid
+	FOUND_VAR ACID_FOUND
+	REQUIRED_VARS _ACID_TARGET_LOCATION
+	)


### PR DESCRIPTION
The AcidConfig shouldn't have `REQUIRED` dependencies because find_dependency already passes that based on how `find_package(Acid)` was called. I also made it work like you'd expect, with an `ACID_FOUND` variable, and a simple message when found.

Also installs resources (if the option is on).