### PR TITLE
cleanup ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,12 @@ matrix:
     - echo $VULKAN_SDK
 
 script:
-- cmake -H. -BBuild
-- cmake --build Build -j 10
+    - mkdir build
+    - cd build
+    - cmake .. -G "Xcode" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_SHARED_LIBS=OFF
+    - xcodebuild -quiet -parallelizeTargets -jobs $(sysctl -n hw.physicalcpu) -target Acid -configuration $BUILD_TYPE | tail -n -90
+
+# cmake -H. -BBuild -G "Xcode"
+# - cd Build
+# - xcodebuild -quiet -parallelizeTargets -jobs $(sysctl -n hw.physicalcpu) -target Acid -configuration $BUILD_TYPE | tail -n -90
+# - cmake --build Build -target Acid -j 10 | tail -n -90

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,14 +82,5 @@ matrix:
     - echo $VULKAN_SDK
 
 script:
-- git submodule update --init --recursive
-- mkdir Build && cd Build
-- |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-      make all -j$(nproc)
-    else
-      cmake .. -G "Xcode" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_SHARED_LIBS=OFF
-      xcodebuild -quiet -parallelizeTargets -jobs $(sysctl -n hw.physicalcpu) -target Acid -configuration $BUILD_TYPE
-    fi
-- cd ../
+- cmake -H. -BBuild
+- cmake --build Build -j 10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,13 +43,15 @@ find_package(Vulkan REQUIRED)
 
 # OpenAL must be installed on the system, env "OPENALDIR" must be set
 find_package(OpenAL REQUIRED)
+
 if(OPENAL_FOUND AND NOT TARGET OpenAL::OpenAL)
 	add_library(OpenAL::OpenAL UNKNOWN IMPORTED)
-	set_target_properties(OpenAL::OpenAL PROPERTIES
+		set_target_properties(OpenAL::OpenAL PROPERTIES
 			IMPORTED_LOCATION "${OPENAL_LIBRARY}"
 			INTERFACE_INCLUDE_DIRECTORIES "${OPENAL_INCLUDE_DIR}")
 endif()
-
+	message("OPENAL_LIBRARY: " ${OPENAL_LIBRARY})
+	message("OPENAL_INCLUDE_DIR: " ${OPENAL_LIBRARY})
 # Used to track if we're using ONLY system libs
 # Prevents errors with EXPORT
 set(_ACID_ALL_SYSTEM_LIBS true)
@@ -183,11 +185,9 @@ if(NOT BULLET_FOUND)
 		foreach(_bullet3_option "BUILD_BULLET3" "BUILD_PYBULLET" "BUILD_BULLET2_DEMOS" "BUILD_OPENGL3_DEMOS" "BUILD_CPU_DEMOS" "BUILD_EXTRAS" "BUILD_UNIT_TESTS" "USE_GRAPHICAL_BENCHMARK" "USE_GLUT" "INSTALL_LIBS" "INSTALL_CMAKE_FILES")
 			set(${_bullet3_option} OFF CACHE INTERNAL "")
 		endforeach()
-
 		if(MSVC OR APPLE)
 			set(BUILD_SHARED_LIBS OFF)
 		endif()
-
 		FetchContent_Populate(bullet3)
 		add_subdirectory(${bullet3_SOURCE_DIR} ${bullet3_BINARY_DIR})
 		# Reset back to value before MSVC fix
@@ -225,4 +225,5 @@ if(BUILD_TESTS)
 	add_subdirectory(Tests/TestPhysics)
 	add_subdirectory(Tests/TestSerial)
 endif()
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,11 @@ if(NOT BULLET_FOUND)
 		foreach(_bullet3_option "BUILD_BULLET3" "BUILD_PYBULLET" "BUILD_BULLET2_DEMOS" "BUILD_OPENGL3_DEMOS" "BUILD_CPU_DEMOS" "BUILD_EXTRAS" "BUILD_UNIT_TESTS" "USE_GRAPHICAL_BENCHMARK" "USE_GLUT" "INSTALL_LIBS" "INSTALL_CMAKE_FILES")
 			set(${_bullet3_option} OFF CACHE INTERNAL "")
 		endforeach()
-		if(MSVC)
+
+		if(MSVC OR APPLE)
 			set(BUILD_SHARED_LIBS OFF)
 		endif()
+
 		FetchContent_Populate(bullet3)
 		add_subdirectory(${bullet3_SOURCE_DIR} ${bullet3_BINARY_DIR})
 		# Reset back to value before MSVC fix

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -130,6 +130,11 @@ if(ACID_LINK_RESOURCES)
 			)
 endif()
 
+if(APPLE)
+add_custom_target(TARGET Acid
+   xcodebuild -quiet -parallelizeTargets -jobs $(sysctl -n hw.physicalcpu) -target Acid -configuration $BUILD_TYPE | tail -n -90 )
+endif()
+
 # Installs all headers, preserving their file structure
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
 		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}"


### PR DESCRIPTION
cmake, as a cross-platform build system, can be used along with the same config/build command among all platforms and let variable like `BUILD_SHARED_LIBS` be deternimated inside cmake file.
```
- cmake -H. -BBuild
- cmake --build Build -j 10
```

As for the job number, things like `j$(nproc)` used in https://github.com/Equilibrium-Games/Acid/commit/b7ce821a6a2b2d4bc441b724fabe1bbd9b9c6b8d not must be fastest: 

- https://travis-ci.org/Equilibrium-Games/Acid/builds/506937129
- https://travis-ci.com/FirstLoveLife/Acid/builds/104652475

`-j 10` is not bad when being used in travis ci