### PR TITLE
PHYSFS_write is deprecated now

### DIFF
--- a/Sources/Files/Files.cpp
+++ b/Sources/Files/Files.cpp
@@ -101,7 +101,7 @@ namespace acid
 				return 0; // no-op
 			}
 
-			if (PHYSFS_write(m_file, pbase(), static_cast<PHYSFS_uint32>(pptr() - pbase()), 1) < 1)
+			if (PHYSFS_writeBytes(m_file, pbase(), static_cast<PHYSFS_uint32>(pptr() - pbase())) < 1)
 			{
 				return traits_type::eof();
 			}


### PR DESCRIPTION
implementation:

```
PHYSFS_sint64 PHYSFS_write(PHYSFS_File *handle, const void *buffer,
                           PHYSFS_uint32 size, PHYSFS_uint32 count)
{
    const PHYSFS_uint64 len = ((PHYSFS_uint64) size) * ((PHYSFS_uint64) count);
    const PHYSFS_sint64 retval = PHYSFS_writeBytes(handle, buffer, len);
    return ( (retval <= 0) ? retval : (retval / ((PHYSFS_sint64) size)) );
} /* PHYSFS_write */
```

> As of PhysicsFS 2.1, use PHYSFS_writeBytes() instead. This function just wraps it anyhow. This function never clarified what would happen if you managed to write a partial object, so working at the byte level makes this cleaner for everyone, especially now that PHYSFS_Io interfaces can be supplied by the application.
