### PR TITLE
workaround for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,16 +17,16 @@ BreakBeforeBraces: Allman
 BreakInheritanceList: AfterColon
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: false
-BreakConstructorInitializers: AfterColon
+BreakConstructorInitializers: BeforeComma
 SpaceAfterTemplateKeyword: false
 # ColumnLimit: 140
 CommentPragmas: '^ IWYU pragma:'
 CommentPragmas:  '^/'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+# ConstructorInitializerAllOnOneLineOrOnePerLine: false
 Cpp11BracedListStyle: true
 FixNamespaceComments: false
 IncludeBlocks: Regroup
-IncludeCategories: 
+IncludeCategories:
   - Regex: '^<.*\.hpp>'
     Priority: 2
   - Regex: '^<.*'

--- a/.clang-format
+++ b/.clang-format
@@ -19,8 +19,9 @@ BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializers: AfterColon
 SpaceAfterTemplateKeyword: false
-ColumnLimit: 140
+# ColumnLimit: 140
 CommentPragmas: '^ IWYU pragma:'
+CommentPragmas:  '^/'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 Cpp11BracedListStyle: true
 FixNamespaceComments: false


### PR DESCRIPTION
```
// Correct
class Texture : 
	public NonCopyable, 
	public Descriptor, 
	public Resource{}
Json::Json(Metadata *metadata) : 
	Metadata("", "")
{
	AddChildren(metadata, this);
}
static std::unique_ptr<uint8_t[]> LoadPixels(const std::string &filename, 
	uint32_t &width, uint32_t &height, uint32_t &components, VkFormat &format);

// Current
class Texture : public NonCopyable, public Descriptor, public Resource{}
Json::Json(Metadata *metadata) : Metadata("", "") { AddChildren(metadata, this); }
static std::unique_ptr<uint8_t[]> LoadPixels(
	const std::string &filename, uint32_t &width, uint32_t &height, uint32_t &components, VkFormat &format);
```

```c++
// My pr
class Texture : 
	public NonCopyable, 
	public Descriptor, 
	public Resource{}
Json::Json(Metadata *metadata)
		: Metadata("", "")
{
	AddChildren(metadata, this);
}
static std::unique_ptr<uint8_t[]> LoadPixels(
	const std::string &filename, uint32_t &width, uint32_t &height, uint32_t &components, VkFormat &format);
```