### PR TITLE
Fixed an issue with joystick initalization.

### DIFF
--- a/Sources/Devices/Joysticks.cpp
+++ b/Sources/Devices/Joysticks.cpp
@@ -30,7 +30,13 @@ Joysticks::Joysticks()
 	{
 		if (glfwJoystickPresent(i))
 		{
-			CallbackJoystick(i, GLFW_CONNECTED);
+			//It may seem tempting to call 'CallbackJoystick' here, but this requires a reference to the module.
+			//As we're currently in the process of adding the module, this will lead to an exception.
+			Joysticks::JoystickImpl joystick = {};
+			joystick.m_name = glfwGetJoystickName(i);
+			m_connected.emplace(i, joystick);
+			//Called for consistency sake, although this can not have an effect.
+			m_onConnect(i, true);
 		}
 	}
 }


### PR DESCRIPTION
Fixed an issue where having a joystick connected during startup would
cause an exception.

This was caused by the joystick module constructor using the callback
which would refer back to the module. As the module was still in the
process of being initialized, this caused the sanitycheck to fail
and the engine to abort.

Because this issue was introduced while cleaning up this code,
a comment has been left to prevent this issue from rising again.

Related issue: #59 