### PR TITLE
Fixed an issue with out of date swapchains.

### DIFF
--- a/Sources/Renderer/Renderer.cpp
+++ b/Sources/Renderer/Renderer.cpp
@@ -58,6 +58,8 @@ void Renderer::Update()
 
 	if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR)
 	{
+		VkExtent2D displayExtent = { Window::Get()->GetSize().m_x, Window::Get()->GetSize().m_y };
+		m_swapchain = std::make_unique<Swapchain>(displayExtent);
 		return;
 	}
 

--- a/Sources/Renderer/Renderpass/Swapchain.cpp
+++ b/Sources/Renderer/Renderpass/Swapchain.cpp
@@ -149,7 +149,7 @@ VkResult Swapchain::AcquireNextImage(const VkSemaphore &presentCompleteSemaphore
 	VkResult acquireResult = vkAcquireNextImageKHR(*logicalDevice, m_swapchain, std::numeric_limits<uint64_t>::max(), presentCompleteSemaphore, VK_NULL_HANDLE,
 		&m_activeImageIndex);
 
-	if (acquireResult != VK_SUCCESS && acquireResult != VK_SUBOPTIMAL_KHR)
+	if (acquireResult != VK_SUCCESS && acquireResult != VK_SUBOPTIMAL_KHR && acquireResult != VK_ERROR_OUT_OF_DATE_KHR)
 	{
 		throw std::runtime_error("Failed to acquire swapchain image");
 		return acquireResult;
@@ -158,7 +158,7 @@ VkResult Swapchain::AcquireNextImage(const VkSemaphore &presentCompleteSemaphore
 	//Renderer::CheckVk(vkWaitForFences(*logicalDevice, 1, &m_fenceImage, VK_TRUE, std::numeric_limits<uint64_t>::max()));
 
 	//Renderer::CheckVk(vkResetFences(*logicalDevice, 1, &m_fenceImage));
-	return VK_SUCCESS;
+	return acquireResult;
 }
 
 VkResult Swapchain::QueuePresent(const VkQueue &presentQueue, const VkSemaphore &waitSemaphore)


### PR DESCRIPTION
Fixed an issue where the swapchain would be invalidated.
This was caused by sanity checking the result of
vkAcquireNextImageKHR; This lead to an explicit std::runtime_error.

Furthermore, AcquireNextImage in Swapchain could only ever return
VK_SUCCESS, and there was no explicit handling for swapchain recreation.

This fixes #61 and seems to stop crashes of several of the tests on Ubuntu with multiple displays (and no Xinerama)