### PR TITLE
Reorder class members. m_thread depend on m_running. …

### DIFF
--- a/Sources/Files/FileWatcher.hpp
+++ b/Sources/Files/FileWatcher.hpp
@@ -49,8 +49,8 @@ private:
 	Time m_delay;
 	Delegate<void(std::string, Status)> m_onChange;
 
+	bool m_running;
 	std::thread m_thread;
 	std::unordered_map<std::string, long> m_paths;
-	bool m_running;
 };
 }


### PR DESCRIPTION
So m_running should put before m_thread. Maybe m_running  is false when m_thread construct.